### PR TITLE
Fix suppress E220: Missing exception

### DIFF
--- a/autoload/wispath.vim
+++ b/autoload/wispath.vim
@@ -78,7 +78,7 @@ export def GetCompletion(target_path: string, cursor_col: number, in_cmdline: bo
     endif
   catch /^Vim\%((\a\+)\)\=:\%(E219\|E220\):/
     # When target_path includes `{` or `}`,
-    # Vim raise `E220: Missing }` or ``E219: Missing {` exception.
+    # Vim raise `E220: Missing }` or `E219: Missing {` exception.
   endtry
   if empty(completions)
     return []

--- a/autoload/wispath.vim
+++ b/autoload/wispath.vim
@@ -76,8 +76,9 @@ export def GetCompletion(target_path: string, cursor_col: number, in_cmdline: bo
     else
       completions = getcompletion(target_path, 'file')
     endif
-  catch
-    # When target_path includes `{`, Vim raise `E220: Missing }` exception.
+  catch /^Vim\%((\a\+)\)\=:\(E219\|E220\):/
+    # When target_path includes `{` or `}`,
+    # Vim raise `E220: Missing }` or ``E219: Missing {` exception.
   endtry
   if empty(completions)
     return []

--- a/autoload/wispath.vim
+++ b/autoload/wispath.vim
@@ -76,7 +76,7 @@ export def GetCompletion(target_path: string, cursor_col: number, in_cmdline: bo
     else
       completions = getcompletion(target_path, 'file')
     endif
-  catch /^Vim\%((\a\+)\)\=:\(E219\|E220\):/
+  catch /^Vim\%((\a\+)\)\=:\%(E219\|E220\):/
     # When target_path includes `{` or `}`,
     # Vim raise `E220: Missing }` or ``E219: Missing {` exception.
   endtry

--- a/autoload/wispath.vim
+++ b/autoload/wispath.vim
@@ -70,11 +70,15 @@ enddef
 
 export def GetCompletion(target_path: string, cursor_col: number, in_cmdline: bool): list<any>
   var completions: list<string>
-  if IsInCmdwin()
-    completions = EvalInAlterWin(function('getcompletion', [target_path, 'file']))
-  else
-    completions = getcompletion(target_path, 'file')
-  endif
+  try
+    if IsInCmdwin()
+      completions = EvalInAlterWin(function('getcompletion', [target_path, 'file']))
+    else
+      completions = getcompletion(target_path, 'file')
+    endif
+  catch
+    # When target_path includes `{`, Vim raise `E220: Missing }` exception.
+  endtry
   if empty(completions)
     return []
   endif

--- a/test/wispath.vimspec
+++ b/test/wispath.vimspec
@@ -252,4 +252,7 @@ Describe wispath#GetCompletion()
     call CompareCandidates(GetCompletion('いろは/'), [strlen('いろは/') + 1, candidates])
   End
 
+  It empty completions with target_path include `{`
+    call CompareCandidates(GetCompletion('{'), [])
+  End
 End

--- a/test/wispath.vimspec
+++ b/test/wispath.vimspec
@@ -255,4 +255,8 @@ Describe wispath#GetCompletion()
   It empty completions with target_path include `{`
     call CompareCandidates(GetCompletion('{'), [])
   End
+
+  It empty completions with target_path include `}`
+    call CompareCandidates(GetCompletion('}'), [])
+  End
 End


### PR DESCRIPTION
Input `{` and run `<c-x><c-f>`, Vim raise `E220: Missing }.`

https://vim-jp.org/vimdoc-ja/message.html#E220

<img width="730" alt="スクリーンショット 2024-12-14 21 29 17" src="https://github.com/user-attachments/assets/dfed9c08-3e09-4ace-9c46-952146363e83" />

I think it better to suppress Vim's exception